### PR TITLE
Add admin page for managing feature flags.

### DIFF
--- a/src/fifteenfortyfive/controllers/admin/feature_flags_controller.cr
+++ b/src/fifteenfortyfive/controllers/admin/feature_flags_controller.cr
@@ -1,0 +1,24 @@
+module Admin::FeatureFlagsController
+  extend BaseController
+  extend self
+
+  def index(env)
+    render_view "admin/feature_flags/index"
+  end
+
+  def enable(env)
+    flag = env.feature_flags[env.params.url["flag_name"]]
+    flag.enabled = true
+    Repo.update(flag)
+
+    env.redirect("/admin/feature_flags")
+  end
+
+  def disable(env)
+    flag = env.feature_flags[env.params.url["flag_name"]]
+    flag.enabled = false
+    Repo.update(flag)
+
+    env.redirect("/admin/feature_flags")
+  end
+end

--- a/src/fifteenfortyfive/models/account.cr
+++ b/src/fifteenfortyfive/models/account.cr
@@ -9,6 +9,7 @@ class Account < Crecto::Model
     field :twitch, String
     field :twitter, String
     field :timezone, String
+    field :admin, Bool
 
     field :password, String, virtual: true
 

--- a/src/fifteenfortyfive/models/feature_flag.cr
+++ b/src/fifteenfortyfive/models/feature_flag.cr
@@ -2,6 +2,9 @@ class FeatureFlag < Crecto::Model
   schema "feature_flags" do
     field :name, String
     field :enabled, Bool, default: true
+
+    set_created_at_field nil
+    set_updated_at_field nil
   end
 
   def self.enabled?(name : String)

--- a/src/fifteenfortyfive/router.cr
+++ b/src/fifteenfortyfive/router.cr
@@ -28,6 +28,18 @@ scope "/register/commentator" do
   post "/revoke", &->CommentatorSubmissionsController.destroy(Krout::Env)
 end
 
+scope "/admin" do
+  before_all do |env|
+    unless env.current_user? && env.current_user.admin
+      halt(env, status_code: 404, response: "Not Found")
+    end
+  end
+
+  get "/feature_flags", &->Admin::FeatureFlagsController.index(Krout::Env)
+  get "/feature_flags/:flag_name/enable",  &->Admin::FeatureFlagsController.enable(Krout::Env)
+  get "/feature_flags/:flag_name/disable", &->Admin::FeatureFlagsController.disable(Krout::Env)
+end
+
 
 get "/", &->StaticController.index(Krout::Env)
 

--- a/src/fifteenfortyfive/views/_layout.slang
+++ b/src/fifteenfortyfive/views/_layout.slang
@@ -27,6 +27,10 @@ html
             p.navbar-text
               a.navbar-link(href="/register") Register
 
+            - if env.current_user? && env.current_user.admin
+              p.navbar-text
+                a.navbar-link(href="/admin/feature_flags") Admin
+
         - if env.feature_flags["signups"].enabled
           .navbar-header.navbar-right
             ul.nav

--- a/src/fifteenfortyfive/views/admin/feature_flags/index.slang
+++ b/src/fifteenfortyfive/views/admin/feature_flags/index.slang
@@ -1,0 +1,23 @@
+.container
+  .row
+    .col-sm-10
+      .page-header
+        h1 Feature Flags
+
+      table.table
+        thead
+          tr
+            th Flag
+            th Status
+            th Toggle
+
+        tbody
+          - env.feature_flags.each do |(name, flag)|
+            tr
+              td= name
+              td= flag.enabled ? "on" : "off"
+              td
+                - if flag.enabled
+                  a(href="/admin/feature_flags/#{name}/disable") Disable
+                -else
+                  a(href="/admin/feature_flags/#{name}/enable") Enable


### PR DESCRIPTION
`/admin/feature_flags` gives admin accounts the ability to toggle feature flags without having to go to the database.