### PR TITLE
Feature/estimated start times

### DIFF
--- a/assets/js/dom-interact/date-localization.js
+++ b/assets/js/dom-interact/date-localization.js
@@ -5,11 +5,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const elements = document.querySelectorAll(".js-date-string.js-localized");
 
   elements.forEach((element) => {
-    const timeString = parseInt(element.innerHTML.trim());
-    const dateTime = DateTime.fromSeconds(timeString);
-    console.log(dateTime)
+    const timeSeconds = parseInt(element.innerHTML.trim());
+    if(isNaN(timeSeconds)) return;
 
-    element.dataset.originalTimeString = timeString;
+    const dateTime = DateTime.fromSeconds(timeSeconds);
+
+    element.dataset.originalTimeSeconds = timeSeconds;
     element.innerHTML = dateTime.toLocaleString({
       year: 'numeric',
       month: 'short',

--- a/db/migrations/20190119201924_add_is_estimate_to_event_dates.sql
+++ b/db/migrations/20190119201924_add_is_estimate_to_event_dates.sql
@@ -1,0 +1,9 @@
+-- +migrate up
+ALTER TABLE "public"."events"
+  ADD COLUMN "start_time_is_estimate" boolean DEFAULT false,
+  ADD COLUMN "end_time_is_estimate" boolean DEFAULT false;
+
+-- +migrate down
+ALTER TABLE "public"."events"
+  DROP COLUMN "start_time_is_estimate",
+  DROP COLUMN "end_time_is_estimate";

--- a/src/fifteenfortyfive/contexts/events.cr
+++ b/src/fifteenfortyfive/contexts/events.cr
@@ -94,4 +94,8 @@ module Events
             minutes.to_i * 60 +
             seconds.to_i
   end
+
+  def accepting_submissions?(event : Event)
+    event.state == "signups open"
+  end
 end

--- a/src/fifteenfortyfive/contexts/events/event.cr
+++ b/src/fifteenfortyfive/contexts/events/event.cr
@@ -27,7 +27,9 @@ module Events
       field :signups_closed_time, Time
       field :runners_announced_time, Time
       field :start_time, Time
+      field :start_time_is_estimate, Bool, default: false
       field :end_time, Time
+      field :end_time_is_estimate, Bool, default: false
 
       field :avatar_object_id, String
       field :link, String

--- a/src/fifteenfortyfive/controllers/events_controller.cr
+++ b/src/fifteenfortyfive/controllers/events_controller.cr
@@ -14,7 +14,10 @@ module EventsController
   end
 
   def show(env)
-    event = Events.get_event!(env.params.url["event_id"], Query.preload(:game))
+    event = Events.get_event!(env.params.url["event_id"], Query.
+      preload(:game).
+      preload(:run_submissions, Query.preload([:account, :game]))
+    )
 
     Template.render(env, "events/show.html.j2", {
       "event" => event

--- a/src/fifteenfortyfive/templates/admin/events/_form.html.j2
+++ b/src/fifteenfortyfive/templates/admin/events/_form.html.j2
@@ -79,6 +79,11 @@
   <div class="control is-expanded">
     <input class="input" type="datetime" name="start_time" value="{{event.start_time}}">
   </div>
+
+  <label class="checkbox">
+    <input type="checkbox" name="start_time_is_estimate">
+    Start Time is Estimated
+  </label>
 </div>
 
 <div class="field">
@@ -86,6 +91,12 @@
   <div class="control is-expanded">
     <input class="input" type="datetime" name="end_time" value="{{event.end_time}}">
   </div>
+
+
+  <label class="checkbox">
+    <input type="checkbox" name="end_time_is_estimate">
+    End Time is Estimated
+  </label>
 </div>
 
 <div class="field">

--- a/src/fifteenfortyfive/templates/events/show.html.j2
+++ b/src/fifteenfortyfive/templates/events/show.html.j2
@@ -70,6 +70,9 @@
                     <span class="js-date-string js-localized">
                       {{ event.start_time | strftime("%s") }}
                     </span>
+                    {% if event.start_time_is_estimate %}
+                      (estimated)
+                    {% endif %}
                   {% else %}
                     Not Set
                   {% endif %}
@@ -81,6 +84,9 @@
                     <span class="js-date-string js-localized">
                       {{ event.end_time | strftime("%s") }}
                     </span>
+                    {% if event.end_time_is_estimate %}
+                      (estimated)
+                    {% endif %}
                   {% else %}
                     Not Set
                   {% endif %}

--- a/src/fifteenfortyfive/templates/events/show.html.j2
+++ b/src/fifteenfortyfive/templates/events/show.html.j2
@@ -33,62 +33,42 @@
                 <p>
                   <span class="info-header">Signups Open</span>
                   <br/>
-                  {% if event.signups_open_time %}
-                    <span class="js-date-string js-localized">
-                      {{ event.signups_open_time | strftime("%s") }}
-                    </span>
-                  {% else %}
-                    Not Set
-                  {% endif %}
+                  <span class="js-date-string js-localized">
+                    {{ event.signups_open_time | strftime("%s", default="Not Set") }}
+                  </span>
                 </p>
                 <p>
                   <span class="info-header">Signups Close</span>
                   <br/>
-                  {% if event.signups_closed_time %}
-                    <span class="js-date-string js-localized">
-                      {{ event.signups_closed_time | strftime("%s") }}
-                    </span>
-                  {% else %}
-                    Not Set
-                  {% endif %}
+                  <span class="js-date-string js-localized">
+                    {{ event.signups_closed_time | strftime("%s", default="Not Set") }}
+                  </span>
                 </p>
                 <p>
                   <span class="info-header">Runners Announced</span>
                   <br/>
-                  {% if event.runners_announced_time %}
-                    <span class="js-date-string js-localized">
-                      {{ event.runners_announced_time | strftime("%s") }}
-                    </span>
-                  {% else %}
-                    Not Set
-                  {% endif %}
+                  <span class="js-date-string js-localized">
+                    {{ event.runners_announced_time | strftime("%s", default="Not Set") }}
+                  </span>
                 </p>
                 <p>
                   <span class="info-header">Event Starts</span>
                   <br/>
-                  {% if event.start_time %}
-                    <span class="js-date-string js-localized">
-                      {{ event.start_time | strftime("%s") }}
-                    </span>
-                    {% if event.start_time_is_estimate %}
-                      (estimated)
-                    {% endif %}
-                  {% else %}
-                    Not Set
+                  <span class="js-date-string js-localized">
+                    {{ event.start_time | strftime("%s", default="Not Set") }}
+                  </span>
+                  {% if event.start_time_is_estimate %}
+                    (estimated)
                   {% endif %}
                 </p>
                 <p>
                   <span class="info-header">Event Ends</span>
                   <br/>
-                  {% if event.end_time %}
-                    <span class="js-date-string js-localized">
-                      {{ event.end_time | strftime("%s") }}
-                    </span>
-                    {% if event.end_time_is_estimate %}
-                      (estimated)
-                    {% endif %}
-                  {% else %}
-                    Not Set
+                  <span class="js-date-string js-localized">
+                    {{ event.end_time | strftime("%s", default="Not Set") }}
+                  </span>
+                  {% if event.end_time_is_estimate %}
+                    (estimated)
                   {% endif %}
                 </p>
               </div>

--- a/src/fifteenfortyfive/templates/events/show.html.j2
+++ b/src/fifteenfortyfive/templates/events/show.html.j2
@@ -75,7 +75,10 @@
             </div>
 
             <div class="buttons has-margin-top-md">
-              <a class="button is-danger is-fullwidth" href="/events/{{event.id}}/submit">Submit a Run</a>
+              {% if event.state == "signups open" %}
+                <a class="button is-danger is-fullwidth" href="/events/{{event.id}}/submit">Submit a Run</a>
+              {% endif %}
+
               <a class="button is-outlined is-fullwidth" href="/events/{{event.id}}/submissions">View Submissions</a>
             </div>
           </div>

--- a/src/fifteenfortyfive/util/template/filters.cr
+++ b/src/fifteenfortyfive/util/template/filters.cr
@@ -21,4 +21,20 @@ module Template
 
     "%02d:%02d:%02d" % [hours, minutes, seconds]
   end
+
+  ENGINE.filters["unique"] = Crinja.filter do |arguments|
+    if target.none?
+      ""
+    elsif arguments.is_set?("attribute")
+      attribute = arguments["attribute"].raw
+      arguments.target!.map do |item|
+        Crinja::Resolver.resolve_getattr(attribute, item)
+      end.uniq
+    else
+      varargs = arguments.varargs
+      filter = env.filters[varargs.shift.as_s!]
+
+      target.to_a.uniq
+    end
+  end
 end

--- a/src/fifteenfortyfive/util/template/filters.cr
+++ b/src/fifteenfortyfive/util/template/filters.cr
@@ -1,9 +1,14 @@
 require "crinja"
 
 module Template
-  ENGINE.filters["strftime"] = Crinja.filter({format: nil}) do |arguments|
-    time    = arguments.target!.as_time
-    format  = arguments["format"].as_s!
+  ENGINE.filters["strftime"] = Crinja.filter({format: nil, default: nil}) do |arguments|
+    begin
+      time = arguments.target!.as_time
+    rescue
+      return arguments["default"]
+    end
+
+    format = arguments["format"].as_s!
     time.to_s(format)
   end
 


### PR DESCRIPTION
Adds a flag to `signups_open_time` and `signups_closed_time` to Events indicating whether the time is final or not to address changes that may happen based on runner's availability.

Also hides the "Submit a Run" button and checks that events are accepting submissions before showing users the submission for.

Also adds the Jinja2.10 `unique` filter for use elsewhere.